### PR TITLE
use min-width: 0 with overflow-wrap: break-word to force text to wrap

### DIFF
--- a/preview-site-src/index.adoc
+++ b/preview-site-src/index.adoc
@@ -98,14 +98,10 @@ The *Server Resources* statistics section displays the resource information on t
 [source,java]
 ----
 // Query (fluent API)
-Observable<AsyncN1qlQueryResult> theAirline = bucket
-    .async()
-    .query(N1qlQuery.simple(
-        select("name")
-            .from("travel-sample")
-            .as("Airline")
-            .where(x("id")
-            .eq(5209))));
+Observable<AsyncN1qlQueryResult> theAirline = bucket.async()
+    .query(
+        N1qlQuery.simple(select("name").from("travel_sample").as("Airline").where(x("id").eq(5209)))
+    );
 return thisAirline;
 ----
 
@@ -279,6 +275,6 @@ Issues resolved in this release:
 
 http://packages.couchbase.com/clients/kafka/3.2.3/kafka-connect-couchbase-3.2.3.zip[kafka-connect-couchbase-3.2.3.zip]
 
-== spec.volumeClaimTemplates.metadata
+== `spec.volumeClaimTemplates.metadata`
 
 This section demonstrates what happens when the section title does not have any natural wrap opportunities.

--- a/src/css/base.css
+++ b/src/css/base.css
@@ -120,6 +120,10 @@ code {
   word-spacing: -0.125em;
 }
 
+html code {
+  hyphens: none;
+}
+
 b,
 strong {
   font-weight: var(--weight-medium);

--- a/src/css/body.css
+++ b/src/css/body.css
@@ -1,24 +1,28 @@
+/* NOTE min-width of flex: 1 container = content-width to prevent wrapping by default; min-width: 0 lets content wrap */
 div.body {
   display: flex;
   margin-top: var(--height-to-body);
+  overflow-wrap: break-word;
 }
 
 main {
   flex: 1;
+  min-width: 0;
 }
 
 nav.nav {
+  /* NOTE reserve no space in layout by default */
+  flex: 0 0 0%;
+  order: -1;
   visibility: hidden;
-  flex: 0;
   /* NOTE width must be set in order for fixed child to inherit */
   width: var(--width-nav);
-  order: -1;
 }
 
 aside.toc.sidebar {
   display: none;
-  flex: 0;
-  /* NOTE width must be set to activate overflow-wrap: break-word (not required for word-break: break-word) */
+  flex: none;
+  /* NOTE lock flex width to width of container */
   width: var(--width-toc);
 }
 
@@ -30,7 +34,8 @@ aside.toc.sidebar {
   nav.nav {
     visibility: visible;
     /* NOTE reserve space for nav in flex layout */
-    flex-basis: var(--width-nav);
+    /* NOTE lock flex width to width of container */
+    flex-basis: auto;
   }
 }
 

--- a/src/css/breadcrumbs.css
+++ b/src/css/breadcrumbs.css
@@ -7,11 +7,15 @@
 }
 
 .crumbs ul {
-  display: inline-flex;
+  display: flex;
   flex-wrap: wrap;
   list-style: none;
   margin: 0;
   padding: 0;
+}
+
+.crumbs li {
+  max-width: 100%;
 }
 
 .crumbs li::after {

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -1,18 +1,7 @@
+/* NOTE in Chrome, hyphens: auto is only supported on macOS and Android */
 .doc p {
   margin: 0;
-}
-
-.doc h1,
-.doc h2,
-.doc h3,
-.doc h4,
-.doc h5,
-.doc h6,
-.doc p,
-/* FIXME td.content might get overzealous */
-.doc td.content {
-  hyphens: auto; /* NOTE: forces long words to break if necessary */
-  word-break: break-word; /* NOTE: Chrome only supports hyphens on macOS and Android */
+  hyphens: auto;
 }
 
 .doc h1,
@@ -24,6 +13,7 @@
   font-weight: var(--weight-normal);
   line-height: 1.2;
   margin: 1.0625rem 0 calc(0.625rem - 1rem) 0;
+  hyphens: auto;
 }
 
 .doc h1 {
@@ -172,14 +162,15 @@
 
 .doc th.tableblock,
 .doc td.tableblock {
-  padding: 0.75rem 1.25rem;
   border-width: 0 1px;
+  /* padding: 0.75rem 1.25rem; */
+  padding: 0.75rem 1rem;
 }
 
 .doc thead th.tableblock {
+  border-width: 1px;
   font-size: 1.0625rem;
   line-height: 1.2;
-  border-width: 1px;
 }
 
 p.tableblock + p.tableblock {
@@ -221,8 +212,9 @@ p.tableblock + p.tableblock {
 }
 
 .doc .admonitionblock > table > tbody {
-  flex: 1;
   display: block;
+  flex: 1;
+  min-width: 0;
 }
 
 .doc .admonitionblock > table > tbody > tr {
@@ -236,9 +228,11 @@ p.tableblock + p.tableblock {
 .doc .admonitionblock td.content {
   display: block;
   flex: 1;
-  padding: 0.75rem 1rem;
   font-size: 0.9375rem;
+  hyphens: auto;
   line-height: 1.6;
+  min-width: 0;
+  padding: 0.75rem 1rem;
 }
 
 .doc .admonitionblock td.content > .title {
@@ -448,10 +442,11 @@ p.tableblock + p.tableblock {
   color: #f8f8f2;
   padding: 0.625rem;
   white-space: pre-wrap;
-  /* NOTE without word-break=break-word, listingblock causes article to overflow bounds */
-  /* NOTE word-break=break-word only works in Chrome, but emulates the behavior of pre-wrap in Firefox */
-  /* NOTE can use width: calc(100vw - var(--width-nav) - var(--width-toc) - var(--width-container-gutter)); on main */
-  word-break: break-word;
+  /* NOTE enable these styles if side-to-side scrolling is preferred */
+  /*
+  overflow-wrap: normal;
+  overflow-x: auto;
+  */
 }
 
 /* NOTE assume pre.highlight contains code[data-lang] */
@@ -603,14 +598,15 @@ p.tableblock + p.tableblock {
   margin-top: 0.5em;
 }
 
-.doc-tiles .toc {
-  display: none !important;
-}
-
-.doc .swagger-ui .opblock-summary-path {
-  word-break: break-word;
+.doc-tiles aside.toc {
+  display: none;
 }
 
 .doc .swagger-ui .wrapper {
   padding: 0;
+  max-width: none;
+}
+
+.doc .swagger-ui .opblock {
+  overflow-x: auto; /* NOTE only seems to be required for Chrome */
 }

--- a/src/css/home.css
+++ b/src/css/home.css
@@ -14,8 +14,8 @@
 .home h1,
 .home h2,
 .home h3 {
-  margin: 0;
   line-height: 1.2;
+  margin: 0;
 }
 
 .home h1.page {
@@ -143,7 +143,8 @@
 
 .blade .ulist {
   font-weight: var(--weight-bold);
-  margin: 1.5rem 0 1rem;
+  margin: 1.5rem 0 0.5rem;
+  overflow-wrap: normal; /* NOTE not sure why this is required, but without it, list items get spaced apart */
 }
 
 .blade a {
@@ -163,6 +164,7 @@
 
 .tiles > h2 {
   font-size: 2rem;
+  hyphens: auto;
   padding-bottom: 3.125rem;
   text-align: center;
 }
@@ -187,12 +189,12 @@
 .tile {
   flex: 1;
   margin-bottom: 0.75rem;
+  min-width: 0;
 }
 
 .home .tile {
-  flex-basis: 50%;
-  max-width: 50%;
-  overflow-wrap: break-word;
+  flex-basis: auto;
+  width: 50%;
 }
 
 .tile .title {

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -12,6 +12,7 @@ main {
 
 .article-header .crumbs {
   flex: 1;
+  min-width: 0;
 }
 
 @media screen and (min-width: 769px) {

--- a/src/css/nav.css
+++ b/src/css/nav.css
@@ -3,7 +3,6 @@
   position: fixed;
   width: inherit;
   overflow-y: scroll;
-  overflow-wrap: break-word;
   font-size: 0.875rem;
   line-height: 1.35;
 }
@@ -110,7 +109,6 @@ html.is-clipped--nav {
 
 .nav.is-active {
   visibility: visible;
-  flex-basis: 0;
 }
 
 .nav.is-active .nav-menu {

--- a/src/css/toc.css
+++ b/src/css/toc.css
@@ -2,11 +2,6 @@
   font-size: 0.875rem;
 }
 
-.toc.sidebar {
-  /* NOTE similar to word-break: break-word in Chrome and word-wrap: break-word in Firefox */
-  overflow-wrap: break-word;
-}
-
 .toc-menu {
   border: 0 solid var(--color-brand-red);
   border-width: 0 0 0 0.25rem;
@@ -17,11 +12,9 @@
 .toc.sidebar .toc-menu {
   position: sticky;
   top: var(--height-to-body);
-  width: inherit;
 }
 
 .toc.embedded .toc-menu {
-  /* margin-top: 1.5rem; */
   margin-top: 1rem;
 }
 

--- a/src/css/toolbar.css
+++ b/src/css/toolbar.css
@@ -1,5 +1,5 @@
 .toolbar ul {
-  display: inline-flex;
+  display: flex;
   list-style: none;
   margin: 0;
   padding: 0;

--- a/src/js/02-on-this-page.js
+++ b/src/js/02-on-this-page.js
@@ -3,13 +3,13 @@
 
   var doc = document.querySelector('article.doc')
   if (!doc) return
-  var menu = document.querySelector('aside.toc.sidebar .toc-menu')
+  var sidebar = document.querySelector('aside.toc.sidebar')
+  var menu
   var headings = find('.sect1 > h2[id]', doc)
   if (!headings.length) {
-    if (menu) menu.parentNode.removeChild(menu)
+    if (sidebar) sidebar.parentNode.removeChild(sidebar)
     return
   }
-  var hasSidebar
   var lastActiveFragment
   var links = {}
 
@@ -25,7 +25,7 @@
     return accum
   }, document.createElement('ol'))
 
-  if (!(hasSidebar = !!menu)) {
+  if (!(menu = sidebar && sidebar.querySelector('.toc-menu'))) {
     menu = document.createElement('div')
     menu.className = 'toc-menu'
   }
@@ -35,18 +35,18 @@
   menu.appendChild(title)
   menu.appendChild(list)
 
-  if (hasSidebar) window.addEventListener('scroll', onScroll)
+  if (sidebar) window.addEventListener('scroll', onScroll)
 
   var startOfContent = doc.querySelector('h1.page + *')
   if (startOfContent) {
     var embeddedToc = document.createElement('aside')
     embeddedToc.className = 'toc embedded'
-    embeddedToc.appendChild(hasSidebar ? menu.cloneNode(true) : menu)
+    embeddedToc.appendChild(menu.cloneNode(true))
     doc.insertBefore(embeddedToc, startOfContent)
   }
 
   function onScroll () {
-    //var targetPosition = doc.parentNode.getBoundingClientRect().top + window.pageYOffset
+    // NOTE equivalent to: doc.parentNode.getBoundingClientRect().top + window.pageYOffset
     var targetPosition = doc.parentNode.offsetTop
     var activeFragment
     headings.some(function (heading) {


### PR DESCRIPTION
- set min-width: 0 anywhere flex: 1 is used (overrides default of content-width to allow content to wrap)
- replace word-break: break-word with overflow-wrap: break-word assigned on .body
- apply hyphens more strategically
- disable hyphens on code
- remove aside.toc.sidebar entirely if no linkable headings are found
- disable flex-shrink on sidebars
- use flex-basis: auto instead of an explicit width
- force breadcrumbs to wrap, if necessary
- fix spacing between list items in blades on home page
- force swagger blocks to scroll, if necessary
- slightly reduce side padding of table cells (to match admonition blocks)
- add example to preview that exhibits wrapping behavior for code in listing block and heading