### PR TITLE
pre-expand current nav item using HTML/CSS

### DIFF
--- a/preview-site-src/ui-model.yml
+++ b/preview-site-src/ui-model.yml
@@ -15,7 +15,7 @@ site:
     latestVersion: *latest_version_abc
   - &component
     name: server
-    title: Couchbase Server
+    title: &component_title Couchbase Server
     url: /server/5.5/index.html
     versions:
     - &latest_version_server
@@ -24,6 +24,7 @@ site:
     - &component_version
       url: '#'
       version: '5.1'
+      title: *component_title
     - url: '#'
       version: '5.0'
     - url: '#'
@@ -50,16 +51,6 @@ page:
   module: ROOT
   home: false
   editUrl: https://github.com/opendevise/couchbase-docs-ui/blob/new-ui/preview-site-src/index.adoc
-  breadcrumbs:
-  - content: Couchbase Server
-    url: *page_url
-    urlType: internal
-  - content: Monitoring
-    url: *page_url
-    urlType: internal
-  - content: *page_title
-    url: *page_url
-    urlType: internal
   versions:
   - version: '5.5'
     url: '#'
@@ -95,11 +86,13 @@ page:
     - content: Users and Security
       url: '#'
       urlType: fragment
-  - content: Managing Clusters
+  - &crumb_0
+    content: Managing Clusters
     items:
-    - content: Monitoring
-      url: '#'
-      urlType: fragment
+    - &crumb_1
+      content: Monitoring
+      url: *page_url
+      urlType: internal
       items:
       - content: Monitor Using the REST API
         url: '#'
@@ -107,7 +100,8 @@ page:
       - content: Monitor Using the cbstats Utility
         url: '#'
         urlType: fragment
-      - content: *page_title
+      - &crumb_2
+        content: *page_title
         url: *page_url
         urlType: internal
       - content: Monitoring XDCR Timestamp-based Conflict Resolution
@@ -135,7 +129,7 @@ page:
       - content: Core File
         url: '#'
         urlType: fragment
-  - content: Installing & Upgrading
+  - content: Installing &amp; Upgrading
     items:
     - content: Couchbase Server Installation Home
       url: '#'
@@ -151,7 +145,7 @@ page:
         - content: Swap Space and Kernel Swappiness
           url: '#'
           urlType: fragment
-      - content: Running Couchbase Server in Containers & Orchestration
+      - content: Running Couchbase Server in Containers &amp; Orchestration
         url: '#'
         urlType: fragment
   - content: Understanding Couchbase
@@ -171,3 +165,7 @@ page:
     - content: content.that.does.not.want.to.wrap.on.its.own
       url: '#'
       urlType: fragment
+  breadcrumbs:
+  - *crumb_0
+  - *crumb_1
+  - *crumb_2

--- a/src/helpers/last.js
+++ b/src/helpers/last.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = (c) => c[c.length - 1]

--- a/src/js/01-nav.js
+++ b/src/js/01-nav.js
@@ -5,9 +5,7 @@
   var navMenu = {}
   if (!(navMenu.element = nav && nav.querySelector('.nav-menu'))) return
   var navControl
-
   var currentPageItem = navMenu.element.querySelector('.is-current-page')
-  if (currentPageItem) expandCurrentPath(currentPageItem)
 
   // NOTE prevent text from being selected by double click
   navMenu.element.addEventListener('mousedown', function (e) { if (e.detail > 1) e.preventDefault() })
@@ -26,20 +24,7 @@
   window.addEventListener('load', fitNavMenuInit)
   window.addEventListener('resize', fitNavMenuInit)
 
-  if ((navControl = document.querySelector('main .nav-control'))) {
-    navControl.addEventListener('click', expandNav)
-  }
-
-  function expandCurrentPath (navItem) {
-    navItem.classList.add('is-active')
-    var ancestorClasses
-    var ancestor = navItem
-    while ((ancestor = ancestor.parentNode) !== navMenu.element) {
-      if ((ancestorClasses = ancestor.classList).contains('nav-item')) {
-        ancestorClasses.add('is-active', 'is-current-path')
-      }
-    }
-  }
+  if ((navControl = document.querySelector('main .nav-control'))) navControl.addEventListener('click', revealNav)
 
   function scrollItemToMiddle (el, parentEl) {
     var adjustment = el.offsetTop + el.offsetHeight + 5 - (parentEl.offsetHeight / 2.0)
@@ -80,24 +65,22 @@
     concealEvent(e)
   }
 
-  function expandNav (e) {
-    if (nav.classList.contains('is-active')) return closeNav(e)
+  function revealNav (e) {
+    if (nav.classList.contains('is-active')) return hideNav(e)
     document.documentElement.classList.add('is-clipped--nav')
     nav.classList.add('is-active')
     nav.addEventListener('click', concealEvent)
-    window.addEventListener('click', closeNav)
-    // NOTE don't let event get picked up by window click listener
-    concealEvent(e)
+    window.addEventListener('click', hideNav)
+    concealEvent(e) // NOTE don't let event get picked up by window click listener
   }
 
-  function closeNav (e) {
+  function hideNav (e) {
     if (e.which === 3 || e.button === 2) return
     document.documentElement.classList.remove('is-clipped--nav')
     nav.classList.remove('is-active')
     nav.removeEventListener('click', concealEvent)
-    window.removeEventListener('click', closeNav)
-    // NOTE don't let event get picked up by window click listener
-    concealEvent(e)
+    window.removeEventListener('click', hideNav)
+    concealEvent(e) // NOTE don't let event get picked up by window click listener
   }
 
   function find (selector, from) {
@@ -114,8 +97,7 @@
     }
   }
 
-  function findNextElement (from) {
-    var el
+  function findNextElement (from, el) {
     if ((el = from.nextElementSibling)) return el
     el = from
     while ((el = el.nextSibling) && el.nodeType !== 1);

--- a/src/partials/breadcrumbs.hbs
+++ b/src/partials/breadcrumbs.hbs
@@ -7,9 +7,9 @@
     {{/if}}
     {{/with}}
     {{#each page.breadcrumbs}}
-    {{#if (and ./url (eq ./urlType 'internal'))~}}
+    {{#if (and ./url (eq ./urlType 'internal'))}}
     <li class="crumb"><a href="{{{relativize @root.page.url ./url}}}">{{{./content}}}</a></li>
-    {{~/if}}
+    {{/if}}
     {{/each}}
   </ul>
   {{/if}}

--- a/src/partials/nav-menu.hbs
+++ b/src/partials/nav-menu.hbs
@@ -1,3 +1,3 @@
 <div class="nav-menu">
-{{> nav-tree navigation=page.navigation}}
+{{> nav-tree navigation=page.navigation level=0 crumbAtLevel=(lookup @root.page.breadcrumbs 0)}}
 </div>

--- a/src/partials/nav-tree.hbs
+++ b/src/partials/nav-tree.hbs
@@ -1,7 +1,9 @@
 {{#if navigation.length}}
 <ul class="nav-list">
   {{#each navigation}}
-  <li class="nav-item{{#if (eq @root.page.url ./url)}} is-current-page{{/if}}{{#if (not ../level)}} is-active{{/if}}" data-depth="{{or ../level 0}}">
+  <li class="nav-item{{#if (eq ../crumbAtLevel this)}}
+      {{~#if (eq this (last @root.page.breadcrumbs))}} is-current-page{{~else}} is-current-path{{/if}} is-active
+      {{~else if (eq ../level 0)}} is-active{{/if}}" data-depth="{{../level}}">
     {{#if ./content}}
     <span class="nav-line">
     {{#if ./items.length}}
@@ -9,14 +11,14 @@
     {{/if}}
     {{#if ./url}}
     <a class="nav-link" href="
-      {{~#if (eq ./urlType 'internal')}}{{{relativize @root.page.url ./url}}}
-      {{~else}}{{{./url}}}{{~/if}}">{{{./content}}}</a>
+        {{~#if (eq ./urlType 'internal')}}{{{relativize @root.page.url ./url}}}
+        {{~else}}{{{./url}}}{{~/if}}">{{{./content}}}</a>
     {{else}}
     <span class="nav-text">{{{./content}}}</span>
     {{/if}}
     </span>
     {{/if}}
-{{> nav-tree navigation=./items level=(increment ../level)}}
+{{> nav-tree navigation=./items level=(increment ../level) crumbAtLevel=(lookup @root.page.breadcrumbs (increment ../level))}}
   </li>
   {{/each}}
 </ul>


### PR DESCRIPTION
- add is-current-path, is-current-page, and is-active classes by comparing item to breadcrumb at current level
- remove JavaScript logic to expand current path in navigation
- convert breadcrumbs in preview UI model to references to items in navigation set 
- set level explicitly when invoking nav-tree partial
- pass crumbAtLevel to nav-tree partial to compare navigation item with breadcrumb at current level
- add last template helper
- escape ampersands in preview UI model
- consolidate lines in 01-nav.js
- indent wrapped logic in handlebars template
- fully populate model for breadcrumbs so they are shown
- don't collapse space between breadcrumb items
- rename closeNav to hideNav
- rename expandNav to revealNav