### PR TITLE
update edit button logic to be compatible with Antora 2

### DIFF
--- a/src/partials/toolbar.hbs
+++ b/src/partials/toolbar.hbs
@@ -6,7 +6,7 @@
   </ul>
 </div>
 {{else}}
-{{#unless (includes page.origin.url '@')}}
+{{#unless (or page.origin.private (includes page.origin.url '@'))}}
 <div class="tools" role="navigation">
   <ul>
     <li class="tool edit"><a href="{{{page.editUrl}}}" title="Edit Page" target="_blank" rel="noopener">Edit</a></li>


### PR DESCRIPTION
Antora 2 provides a dedicated property on origin to determine whether the repository is private (aka requires auth).

This change will not impact the UI when used with Antora 1.x.