### PR TITLE
Updates for archive site

### DIFF
--- a/src/helpers/related-sdk-pages.js
+++ b/src/helpers/related-sdk-pages.js
@@ -7,7 +7,7 @@ module.exports = (langs, { data: { root } }) => {
   return langs
     .split(',')
     .map((lang) => lang + '-sdk')
-    .filter((componentName) => componentName !== thisComponentName)
+    .filter((componentName) => !(componentName === thisComponentName || (components[componentName] || {}).origin))
     .map((componentName) => {
       const component = components[componentName]
       if (component) {

--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -32,7 +32,9 @@
                   <li><a href="{{relativize this}}">Analytics</a></li>
                   {{/with}}
                   {{#with site.components.operator}}
+                  {{#unless ./origin}}
                   <li><a href="{{relativize ./url}}">Kubernetes</a></li>
+                  {{/unless}}
                   {{/with}}
                 </ul>
                 <ul>
@@ -49,7 +51,13 @@
                   <li><a href="{{relativize site.components.php-sdk.url}}">PHP</a></li>
                   <li><a href="{{relativize site.components.go-sdk.url}}">Go</a></li>
                   <li><a href="{{relativize site.components.c-sdk.url}}">C</a></li>
+                  {{#with site.components.scala-sdk}}
+                  {{#unless ./origin}}
+                  <li><a href="{{relativize ./url}}">Scala</a></li>
+                  {{/unless}}
+                  {{else}}
                   <li><a href="{{relativize site.components.scala-sdk.url}}">Scala</a></li>
+                  {{/with}}
                 </ul>
                 <ul>
                   <li class="heading"><a href="{{relativize (resolvePageURL 'server:connectors:intro.adoc')}}">Connectors</a></li>

--- a/src/partials/main.hbs
+++ b/src/partials/main.hbs
@@ -1,12 +1,16 @@
 <main class="article" data-ceiling="topbar">
-  {{#unless (or page.attributes.hide-view-latest (eq page.componentVersion page.component.latest))}}
+  {{#unless (or page.attributes.hide-view-latest (eq page.componentVersion (or page.component.preferred page.component.latest)))}}
   <div class="article-banner">
     {{#if page.componentVersion.prerelease}}
     <p>You are viewing the documentation for a prerelease version.</p>
     {{else}}
     <p>A newer version of this documentation is available.</p>
     {{/if}}
+    {{#with page.component.preferred}}
+    <a class="btn" href="{{relativize (or (resolvePageURL @root.page.relativeSrcPath version=./version) ./url)}}">View Latest</a>
+    {{else}}
     <a class="btn" href="{{#if (eq env.SUPPORTS_CURRENT_URL 'true')}}{{relativize (current-url page.url)}}{{else}}{{relativize page.latest.url}}{{/if}}">View Latest</a>
+    {{/with}}
   </div>
   {{/unless}}
   <div class="article-header">


### PR DESCRIPTION
Updates to accommodate requirements for the archive site. These changes will eventually get rolled into the main UI, but that will require upgrading to Antora 2.3.