### PR TITLE
bg highlight the current page on left-side nav menu

### DIFF
--- a/src/css/nav.css
+++ b/src/css/nav.css
@@ -94,6 +94,7 @@
 }
 
 .nav-menu .nav-item.is-current-page > .nav-line > a.nav-link {
+  background-color: #e0e0e0;
   color: var(--color-text);
   font-weight: var(--weight-medium);
 }

--- a/src/css/nav.css
+++ b/src/css/nav.css
@@ -95,6 +95,8 @@
 
 .nav-menu .nav-item.is-current-page > .nav-line > a.nav-link {
   background-color: #e0e0e0;
+  border-bottom: 1.5px solid var(--color-brand-orange);
+  margin-bottom: -1.5px;
   color: var(--color-text);
   font-weight: var(--weight-medium);
 }


### PR DESCRIPTION
This change makes the left-side nav menu hierarchy have a background
color that highlights the current docs page to make it easier to navigate.