### PR TITLE
minor updates to leverage UI model in Antora 2.3

### DIFF
--- a/preview-src/ui-model.yml
+++ b/preview-src/ui-model.yml
@@ -1,4 +1,4 @@
-antoraVersion: '1.1.1'
+antoraVersion: '3.2.1'
 site:
   url: /home.html
   title: Couchbase Docs

--- a/src/helpers/home-edit-url.js
+++ b/src/helpers/home-edit-url.js
@@ -1,6 +1,0 @@
-'use strict'
-
-const SEARCH_RX = /^.*(?=\/home\/)/
-
-module.exports = (editUrl, baseUrl, branch) =>
-  editUrl.replace(SEARCH_RX, `${baseUrl}/edit/${branch === 'HEAD' ? 'master' : branch}`)

--- a/src/helpers/not.js
+++ b/src/helpers/not.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = (val) => !val

--- a/src/partials/body.hbs
+++ b/src/partials/body.hbs
@@ -1,4 +1,4 @@
-<div class="body container{{#if page.attributes.role}} {{page.attributes.role}}{{/if}}">
+<div class="body container{{#with (or page.role page.attributes.role)}} {{{this}}}{{/with}}">
 {{> nav}}
 {{> toc}}
 {{> main}}

--- a/src/partials/head-meta.hbs
+++ b/src/partials/head-meta.hbs
@@ -1,15 +1,13 @@
-    {{#if page.component}}
     {{#if page.description}}
     <meta name="description" content="{{page.description}}">
     {{/if}}
     {{#if page.keywords}}
     <meta name="keywords" content="{{page.keywords}}">
     {{/if}}
+    {{#if page.component}}
     <link rel="schema.dcterms" href="https://purl.org/dc/terms/">
     <meta name="dcterms.subject" content="{{page.component.name}}">
     <meta name="dcterms.identifier" content="{{page.version}}">
     {{/if}}
-    {{#if (or antoraVersion site.antoraVersion)}}
-    <meta name="generator" content="Antora {{or antoraVersion site.antoraVersion}}">
-    {{/if}}
+    <meta name="generator" content="Antora {{antoraVersion}}">
     <link rel="icon" href="{{uiRootPath}}/img/favicon.ico" type="image/x-icon">

--- a/src/partials/toolbar.hbs
+++ b/src/partials/toolbar.hbs
@@ -1,17 +1,7 @@
-{{#if page.editUrl}}
-{{#if (eq page.component.name 'home')}}
+{{#if (or (and page.fileUri (not env.CI)) (and page.editUrl (not page.origin.private)))}}
 <div class="tools" role="navigation">
   <ul>
-    <li class="tool edit"><a href="{{home-edit-url page.editUrl 'https://github.com/couchbase/docs-site' page.origin.branch}}" title="Edit Page" target="_blank" rel="noopener">Edit</a></li>
+    <li class="tool edit"><a href="{{#if (and page.fileUri (not env.CI))}}{{page.fileUri}}{{else}}{{page.editUrl}}{{/if}}" title="Edit Page" target="_blank" rel="noopener">Edit</a></li>
   </ul>
 </div>
-{{else}}
-{{#unless (and (or page.origin.private (includes page.origin.url '@')) (ne page.origin.worktree true))}}
-<div class="tools" role="navigation">
-  <ul>
-    <li class="tool edit"><a href="{{page.editUrl}}" title="Edit Page" target="_blank" rel="noopener">Edit</a></li>
-  </ul>
-</div>
-{{/unless}}
-{{/if}}
 {{/if}}


### PR DESCRIPTION
Note that the home-edit-url helper is no longer required as the necessary logic is now built into Antora.